### PR TITLE
when calling wasi, it report "missing imported function"

### DIFF
--- a/crates/wasm3-provider/src/lib.rs
+++ b/crates/wasm3-provider/src/lib.rs
@@ -136,7 +136,7 @@ impl WebAssemblyEngineProvider for Wasm3EngineProvider {
     let module = Module::parse(&env, bytes.as_ref()).to_wapc()?;
 
     let mut module = rt.load_module(module).to_wapc()?;
-
+    module.link_wasi().to_wapc()?;
     let h = host.clone();
     if let Err(_e) = module.link_closure(
       HOST_NAMESPACE,


### PR DESCRIPTION
resolve the problem:
```
cargo run -p wasm3-provider --example wasm3-demo ./wasm/crates/wasi-basic/build/wasi_basic.wasm ping "hi"
……
[2022-04-28T06:45:36Z ERROR wasm3_provider] Failed during invocation of starter function 'wapc_init': missing imported function.
Error: InitFailed("Failed during starter initialization 'wapc_init': missing imported function")
```