### PR TITLE
wasmtime-provider - release v1.0.1

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-provider"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",
@@ -29,15 +29,15 @@ wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.0.0" }
 log = "0.4"
-wasmtime = "0.37.0"
+wasmtime = "0.38.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.11"
 
 # feature = wasi
-wasmtime-wasi = { version = "0.37.0", optional = true }
-wasi-common = { version = "0.37", optional = true }
-wasi-cap-std-sync = { version = "0.37", optional = true }
+wasmtime-wasi = { version = "0.38.0", optional = true }
+wasi-common = { version = "0.38", optional = true }
+wasi-cap-std-sync = { version = "0.38", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }


### PR DESCRIPTION
We just merged https://github.com/wapc/wapc-rs/pull/6 and a new version of wasmtime got out 2 days ago :rofl: 

This PR upgades to the latest release of wasmtime and performs a bump of the wasmtime-provider.

Can we tag a new release once this PR is merged please?
