### PR TITLE
Version bump of wasmtime-provider

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-provider"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",


### PR DESCRIPTION
Tag a patch release that updates the wasmtime dependencies.

Needed after https://github.com/wapc/wapc-rs/pull/9 got merged.
