### PR TITLE
wasmtime provider bump

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -29,15 +29,15 @@ wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.0.0" }
 log = "0.4"
-wasmtime = "0.39.0"
+wasmtime = "0.40.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.11"
 
 # feature = wasi
-wasmtime-wasi = { version = "0.39", optional = true }
-wasi-common = { version = "0.39", optional = true }
-wasi-cap-std-sync = { version = "0.39", optional = true }
+wasmtime-wasi = { version = "0.40", optional = true }
+wasi-common = { version = "0.40", optional = true }
+wasi-cap-std-sync = { version = "0.40", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }

--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-provider"
-version = "1.0.2"
+version = "1.1.0"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",

--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -30,6 +30,7 @@ wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
 wapc = { path = "../wapc", version = "1.0.0" }
 log = "0.4"
 wasmtime = "0.40.0"
+anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.11"

--- a/crates/wasmtime-provider/src/errors.rs
+++ b/crates/wasmtime-provider/src/errors.rs
@@ -4,12 +4,16 @@ pub enum Error {
   /// WASMTime initialization failed
   #[error("Initialization failed: {0}")]
   InitializationFailed(Box<dyn std::error::Error + Send + Sync>),
+
   /// The guest call function was not exported by the guest.
   #[error("Guest call function (__guest_call) not exported by wasm module.")]
   GuestCallNotFound,
   /// Error originating from [wasi_common]
   #[error("{0}")]
   WasiError(#[from] wasi_common::Error),
+  /// Error originating when wasi feature is disabled, but the user provides wasi related params
+  #[error("WASI related parameter provided, but wasi feature is disabled")]
+  WasiDisabled,
 }
 
 impl From<Error> for wapc::errors::Error {

--- a/crates/wasmtime-provider/src/errors.rs
+++ b/crates/wasmtime-provider/src/errors.rs
@@ -8,12 +8,15 @@ pub enum Error {
   /// The guest call function was not exported by the guest.
   #[error("Guest call function (__guest_call) not exported by wasm module.")]
   GuestCallNotFound,
-  /// Error originating from [wasi_common]
-  #[error("{0}")]
-  WasiError(#[from] wasi_common::Error),
+
   /// Error originating when wasi feature is disabled, but the user provides wasi related params
   #[error("WASI related parameter provided, but wasi feature is disabled")]
   WasiDisabled,
+
+  /// Generic error
+  // wasmtime uses `anyhow::Error` inside of its public API
+  #[error(transparent)]
+  Generic(#[from] anyhow::Error),
 }
 
 impl From<Error> for wapc::errors::Error {

--- a/crates/wasmtime-provider/src/lib.rs
+++ b/crates/wasmtime-provider/src/lib.rs
@@ -91,9 +91,13 @@ use wapc::{wapc_functions, ModuleState, WasiParams, WebAssemblyEngineProvider, H
 // the very same version
 pub use wasmtime;
 use wasmtime::{AsContextMut, Engine, Extern, ExternType, Instance, Linker, Module, Store, TypedFunc};
-#[cfg(feature = "wasi")]
-pub use wasmtime_wasi;
-use wasmtime_wasi::WasiCtx;
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "wasi")] {
+        pub use wasmtime_wasi;
+        use wasmtime_wasi::WasiCtx;
+    }
+}
 
 // namespace needed for some language support
 const WASI_UNSTABLE_NAMESPACE: &str = "wasi_unstable";


### PR DESCRIPTION
Upgrade the wasmtime-provide to use latest stable release of wasmtime: v0.40. This is a minor relase of wasmtime, which happens to break some public APIs.

This PR fixes the compilation issues introduces by the breaking changes.

The most important one is the one fixed by 8ed2e19991530d91b2014e5ab899dca4225df8cd . This commit causes `wasmtime_provider::errors::Error` to drop on variant and gain a new one.
Because of this change, I think it would be better to tag the next release of wasmtime_provider as `1.1.0` instead of doing a patch relase.

I tried hard to avoid this breaking change, but that doesn't seem possible.

This is the commit message that explains what happened.

> Updating to wasmtime 0.40 breaks waasmtime-provider own `Error` enum when the `wasi` feature is disabled.
> 
> When the `wasi` feature is disabled, the `wasi_common::Error` is no longer defined. That causes `wasmtime_provider::Error::WasiError` variant definition to break.
> 
> It is possible to hide this enum variant definition behind a `cfg` check, and prevent its definition when the `wasi` feature is disabled.
> However, when this is done, the code will break in some other parts when the `?` operator attempts to convert a `anyhow::Error` into a `wasmtime_provider::Error`.
> The `wasmtime` create doesn't define a custom error type, but instead has many APIs returning a `anyhow::Result` (which is a `Result` returning a `anyhow::Error` type of error). This includes methods like `wasmtime::Module.new`.
> 
> This compilation error can be solved by defining a new variant inside of `wasmtime_provider::Error`, which transparently maps `anyhow::Error`. Unfortunately, this breaks the compilation when the `wasi` feature is enabled. The compilation fails because there are two conflicting implementations of `std::convert::From<anyhow::Error>`.
> 
> This commit removes the `wasmtime_provider::Error::WasiError` variant and introduces a `Generic` variant that can handle all `anyhow::Error` transformations.
