### PR TITLE
wasmtime-provider: improve `WasmtimeProvider::clone` performance

### DIFF
--- a/crates/wapc-pool/examples/pool.rs
+++ b/crates/wapc-pool/examples/pool.rs
@@ -8,7 +8,9 @@ use wapc_pool::HostPoolBuilder;
 async fn main() -> anyhow::Result<()> {
   let buf = read("./wasm/crates/wapc-guest-test/build/wapc_guest_test.wasm")?;
 
-  let engine = wasmtime_provider::WasmtimeEngineProviderBuilder::new(&buf).build()?;
+  let engine = wasmtime_provider::WasmtimeEngineProviderBuilder::new()
+    .module_bytes(&buf)
+    .build()?;
 
   let pool = HostPoolBuilder::new()
     .name("pool example")

--- a/crates/wapc-pool/tests/benchmark.rs
+++ b/crates/wapc-pool/tests/benchmark.rs
@@ -14,7 +14,9 @@ async fn benchmark() -> Result<(), errors::Error> {
   let num_threads: u32 = 10;
   let num_calls: u32 = 100;
 
-  let engine = wasmtime_provider::WasmtimeEngineProviderBuilder::new(&buf).build()?;
+  let engine = wasmtime_provider::WasmtimeEngineProviderBuilder::new()
+    .module_bytes(&buf)
+    .build()?;
   let pool = HostPoolBuilder::new()
     .name("wasmtime-test")
     .factory(move || {

--- a/crates/wasmtime-provider/examples/wasmtime-demo.rs
+++ b/crates/wasmtime-provider/examples/wasmtime-demo.rs
@@ -17,7 +17,9 @@ pub fn main() -> Result<(), wapc::errors::Error> {
     .expect("The string payload to send should be passed as the third CLI parameter");
 
   let module_bytes = std::fs::read(file).expect("WASM could not be read");
-  let engine = WasmtimeEngineProviderBuilder::new(&module_bytes).build()?;
+  let engine = WasmtimeEngineProviderBuilder::new()
+    .module_bytes(&module_bytes)
+    .build()?;
 
   let host = WapcHost::new(Box::new(engine), Some(Box::new(host_callback)))?;
 

--- a/crates/wasmtime-provider/src/builder.rs
+++ b/crates/wasmtime-provider/src/builder.rs
@@ -6,7 +6,8 @@ use crate::WasmtimeEngineProvider;
 #[derive(Default)]
 pub struct WasmtimeEngineProviderBuilder<'a> {
   engine: Option<wasmtime::Engine>,
-  module_bytes: &'a [u8],
+  module: Option<wasmtime::Module>,
+  module_bytes: Option<&'a [u8]>,
   #[cfg(feature = "cache")]
   cache_enabled: bool,
   #[cfg(feature = "cache")]
@@ -17,14 +18,28 @@ pub struct WasmtimeEngineProviderBuilder<'a> {
 
 #[allow(deprecated)]
 impl<'a> WasmtimeEngineProviderBuilder<'a> {
-  /// A new WasmtimeEngineProviderBuilder instance,
-  /// must provide the wasm module to be loaded
+  /// Create a builder instance
   #[must_use]
-  pub fn new(module_bytes: &'a [u8]) -> Self {
-    WasmtimeEngineProviderBuilder {
-      module_bytes,
-      ..Default::default()
-    }
+  pub fn new() -> Self {
+    Default::default()
+  }
+
+  /// Provide contents of the WebAssembly module
+  #[must_use]
+  pub fn module_bytes(mut self, module_bytes: &'a [u8]) -> Self {
+    self.module_bytes = Some(module_bytes);
+    self
+  }
+
+  /// Provide a preloaded [`wasmtime::Module`]
+  ///
+  /// **Warning:** the [`wasmtime::Engine`] used to load it must be provided via the
+  /// [`WasmtimeEngineProviderBuilder::engine`] method, otherwise the code
+  /// will panic at runtime later.
+  #[must_use]
+  pub fn module(mut self, module: wasmtime::Module) -> Self {
+    self.module = Some(module);
+    self
   }
 
   /// Provide a preinitialized [`wasmtime::Engine`]

--- a/crates/wasmtime-provider/src/errors.rs
+++ b/crates/wasmtime-provider/src/errors.rs
@@ -22,6 +22,23 @@ pub enum Error {
   #[error("WASI related parameter provided, but wasi feature is disabled")]
   WasiDisabled,
 
+  /// Error originating when wasi context initialization fails
+  #[error("WASI context initialization failed: {0}")]
+  WasiInitCtxError(String),
+
+  /// Error caused when a host function cannot be registered into a wasmtime::Linker
+  #[error("Linker cannot register function '{func}': {err}")]
+  LinkerFuncDef {
+    /// wasm function that was being defined
+    func: String,
+    /// error reported
+    err: String,
+  },
+
+  /// Error caused by an invalid configuration of the [`WasmtimeEngineProviderBuilder`]
+  #[error("Invalid WasmtimeEngineProviderBuilder configuration: {0}")]
+  BuilderInvalidConfig(String),
+
   /// Generic error
   // wasmtime uses `anyhow::Error` inside of its public API
   #[error(transparent)]

--- a/crates/wasmtime-provider/src/lib.rs
+++ b/crates/wasmtime-provider/src/lib.rs
@@ -219,10 +219,10 @@ impl WasmtimeEngineProvider {
     let mut config = wasmtime::Config::new();
     config.strategy(wasmtime::Strategy::Cranelift);
     if let Some(cache) = cache_path {
-      config.cache_config_load(cache)?;
-    } else if let Err(e) = config.cache_config_load_default() {
-      warn!("Wasmtime cache configuration not found ({}). Repeated loads will speed up significantly with a cache configuration. See https://docs.wasmtime.dev/cli-cache.html for more information.",e);
-    }
+      config.cache_config_load(cache)
+    } else {
+      config.cache_config_load_default()
+    }?;
     let engine = Engine::new(&config)?;
     Self::new_with_engine(buf, engine, wasi)
   }

--- a/crates/wasmtime-provider/tests/hello.rs
+++ b/crates/wasmtime-provider/tests/hello.rs
@@ -7,9 +7,12 @@ fn create_guest(path: &str) -> Result<WapcHost, Error> {
   let buf = read(path)?;
   cfg_if::cfg_if! {
     if #[cfg(feature = "cache")] {
-        let builder = wasmtime_provider::WasmtimeEngineProviderBuilder::new(&buf).enable_cache(None);
+        let builder = wasmtime_provider::WasmtimeEngineProviderBuilder::new()
+            .module_bytes(&buf).
+            enable_cache(None);
     } else {
-        let builder = wasmtime_provider::WasmtimeEngineProviderBuilder::new(&buf);
+        let builder = wasmtime_provider::WasmtimeEngineProviderBuilder::new()
+            .module_bytes(&buf);
     }
   }
   let engine = builder.build().expect("Cannot create WebAssemblyEngineProvider");
@@ -75,7 +78,8 @@ fn runs_wapc_timeout() -> Result<(), Error> {
   engine_conf.epoch_interruption(true);
   let engine = wasmtime::Engine::new(&engine_conf).expect("cannot create wasmtime engine");
 
-  let wapc_engine_builder = wasmtime_provider::WasmtimeEngineProviderBuilder::new(&module_bytes)
+  let wapc_engine_builder = wasmtime_provider::WasmtimeEngineProviderBuilder::new()
+    .module_bytes(&module_bytes)
     .engine(engine.clone())
     .enable_epoch_interruptions(wapc_init_deadline, wapc_func_deadline);
   let guest = create_guest_from_builder(&wapc_engine_builder)?;

--- a/crates/wasmtime-provider/tests/wapc_guest.rs
+++ b/crates/wasmtime-provider/tests/wapc_guest.rs
@@ -7,7 +7,9 @@ use wapc_codec::messagepack::{deserialize, serialize};
 fn runs_wapc_guest() -> Result<(), errors::Error> {
   let buf = read("../../wasm/crates/wapc-guest-test/build/wapc_guest_test.wasm")?;
 
-  let engine = wasmtime_provider::WasmtimeEngineProviderBuilder::new(&buf).build()?;
+  let engine = wasmtime_provider::WasmtimeEngineProviderBuilder::new()
+    .module_bytes(&buf)
+    .build()?;
   let guest = WapcHost::new(Box::new(engine), Some(Box::new(move |_a, _b, _c, _d, _e| Ok(vec![]))))?;
 
   let callresult = guest.call("echo", &serialize("hello world").unwrap())?;


### PR DESCRIPTION
This is quite a big refactoring, I'm a bit sorry about that. Unfortunately there was no other way to implement it.

The main points are:

  * Breaking: the wasmtime_provider::WasmtimeEngineProviderBuilder::new` API had been changed
  * `wasmtime_provider::WasmtimeEngineProviderBuilder`: allow user to provide a `wasmtime::Module` instance
  * fix: make `WasmtimeEngineProvider::clone` 72% faster
  * refactoring: have waPC host callbacks raise proper `wasmtime::Trap` instead of panicking

The majority of the changes have been required to make use of some `wasmtime` features, so that `WasmtimeEngineProvider::clone` would be faster.

## Improve WasmtimeEngineProvider::clone performance

This improves the execution of `WasmtimeEngineProvider::clone()` by 72%.

This is extremely useful for FaaS-like contexts, where on new requests a `WasmtimeEngineProvider` instance is cloned just to serve the incoming data.

This improvement required quite some code refactoring. Details are below.

### The bottleneck

The bottleneck was inside of the `WasmtimeEngineProvider::init()` method, which is     called by `wapc::WapcHost`.
This method used to take a `wasmtime::Module` and iterate over     a list of all the imported functions.
The code then would build an array with all the functions to be imported,    both the WASI and the waPC ones.
Finally, the code would create a `wasmtime::Instance`.

Instantiating a module is a time consuming operation, that was done    every time `WasmtimeEngineProvider::clone()` was invoked.

This process was needed to register all the waPC functions, which     require to have access to the `host` instance.

This commit moves the `host` instance into the `WapcStore` object, which    is accessible via the `wasmtime::Store`. The store is then accessible    inside of the closures defining the waPC callbacks.

All the waPC callbacks have been rewritten to obtain the `host`    instance by accessing the local store.
This makes possible to register all the waPC callbacs as soon as the    `wasmtime::Linker` is created. This is similar to how WASI functions are made     available to the linker. This allows an important optimization.

When `WasmtimeEngineProvider` is created, the code creates a `wasmtime::Store`     that has inside of it a temporary instance of `WapcHost`.
This instance doesn't have a `host` set, but this isn't a problem since    the functions are not executed yet.
Then, using a `wasmtime::Linker` and this temporary store, we create a    `wasmtime::InstancePre` which is then saved into the    `WasmtimeEngineProvider` instance. Instantiating a module is a time    expensive operation. The `wasmtime::InstancePre` allows us to pay this    cost just once.

When `WasmtimeEngineProvider::init` happes, we create the    final `WapcHost` object using the `host` instance received as    a parameter by the method.
Then we use the `wasmtime::InstancePre::instantiate` method to create    the actual `wasmtime::Instance`.

To summarize: with this code the module instantiation fee is paid only    once, when the first `WasmtimeEngineProvider` is created. All the next    `clone()` operations are not going to be slowed down by it.

## Code cleanups

While rewriting all the waPC callbacks, all the `unwrap` invocations    have been removed. The functions now raise proper `wasmtime::Trap` when    something goes wrong.

## The `WasmtimeEngineProviderPre` struct

With `wasmtime_provider` 1.2.0 release, the    `WasmtimeEngineProviderBuilder` struct was introduced and the `new` methods    of `WasmtimeEngineProvider` got deprecated.

The code inside of the deprecated `new` methods have been moved into    `WasmtimeEngineProviderPre`, which is now consumed by the builder.

The `WasmtimeEngineProviderPre` has a `rehydrate` method that can be    used to generate a `WasmtimeEngineProvider` instance.
This method is faster than `WasmtimeEngineProvider::clone()` by 10    microseconds. I expected it to be faster, that's why I decided to not    make the struct public.

