### PR TITLE
Wasmtime provider: 1.3.0 release

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -29,16 +29,16 @@ wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.0.0" }
 log = "0.4"
-wasmtime = "0.40.0"
+wasmtime = "1.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.11"
 
 # feature = wasi
-wasmtime-wasi = { version = "0.40", optional = true }
-wasi-common = { version = "0.40", optional = true }
-wasi-cap-std-sync = { version = "0.40", optional = true }
+wasmtime-wasi = { version = "1.0", optional = true }
+wasi-common = { version = "1.0", optional = true }
+wasi-cap-std-sync = { version = "1.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }

--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-provider"
-version = "1.2.0"
+version = "1.3.0"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",


### PR DESCRIPTION
> **NOTE:** this PR is built on top of https://github.com/wapc/wapc-rs/pull/15

Tag a new release of wasmtime-provider