### PR TITLE
update to wasmtime v3

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -30,16 +30,16 @@ wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.0.0" }
 log = "0.4"
-wasmtime = "2.0"
+wasmtime = "3.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.11"
 
 # feature = wasi
-wasmtime-wasi = { version = "2.0", optional = true }
-wasi-common = { version = "2.0", optional = true }
-wasi-cap-std-sync = { version = "2.0", optional = true }
+wasmtime-wasi = { version = "3.0", optional = true }
+wasi-common = { version = "3.0", optional = true }
+wasi-cap-std-sync = { version = "3.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }

--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-provider"
-version = "1.3.1"
+version = "1.3.2"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",


### PR DESCRIPTION
Update to the latest stable release of wasmtime (3.0.0).
The public `Trap` API changed, hence some of our code had to be fixed.

**Important:** wasmtime-provider has been bumped to version `1.3.2`. A new tag of the crate has to be published
