### PR TITLE
fix: wapc-guest avoid panic after wasmtime interruption

### DIFF
--- a/crates/wapc-guest/Cargo.toml
+++ b/crates/wapc-guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wapc-guest"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",


### PR DESCRIPTION
When using wasmtime's ["epoch interruption feature"](https://docs.rs/wasmtime/4.0.0/wasmtime/struct.Config.html#method.consume_fuel) and [consume fuel](https://docs.rs/wasmtime/4.0.0/wasmtime/struct.Config.html#method.consume_fuel) features, the execution of a waPC guest can be interrupted at any time.

When the interruption takes place no code cleanup is executed. If the same module instance is used again, this can lead to side effects if the code is using global variables.

Having "stateful" modules is a developer decision, however waPC-guest itself defines a global variable which is protected by a Mutex. This is the `REGISTRY` hashmap variable that contains all the registered waPC functions exposed by the guest.

The usage of a Mutex is problematic because, when resuming an interrupted instance, this leads to an immediate panic error. When the `__guest_request` function is invoked by the host, the waPC guest will immediately attempt to take a lock on the Mutex. Unfortunately the Mutex has already been locked by the prior - interrupted - execution. Hence a panic is raised by the Rust guest code.

With this commit, the Mutex is replaced by a RwLock. This is more flexible and should also perform a bit better, because the majority of the operations done against the `REGISTRY` hashmap are `read` requests.

Writes are done only when registering the waPC functions, which happens once.



