### PR TITLE
update wasmtime

### DIFF
--- a/crates/wapc-codec/src/lib.rs
+++ b/crates/wapc-codec/src/lib.rs
@@ -44,7 +44,6 @@
   clippy::equatable_if_let,
   bad_style,
   clashing_extern_declarations,
-  const_err,
   dead_code,
   deprecated,
   explicit_outlives_requirements,

--- a/crates/wapc-guest/src/lib.rs
+++ b/crates/wapc-guest/src/lib.rs
@@ -44,7 +44,6 @@
   clippy::equatable_if_let,
   bad_style,
   clashing_extern_declarations,
-  const_err,
   dead_code,
   deprecated,
   explicit_outlives_requirements,

--- a/crates/wapc-pool/src/lib.rs
+++ b/crates/wapc-pool/src/lib.rs
@@ -44,7 +44,6 @@
   clippy::future_not_send,
   bad_style,
   clashing_extern_declarations,
-  const_err,
   dead_code,
   deprecated,
   explicit_outlives_requirements,

--- a/crates/wapc/src/lib.rs
+++ b/crates/wapc/src/lib.rs
@@ -44,7 +44,6 @@
   clippy::equatable_if_let,
   bad_style,
   clashing_extern_declarations,
-  const_err,
   dead_code,
   deprecated,
   explicit_outlives_requirements,

--- a/crates/wasm3-provider/src/lib.rs
+++ b/crates/wasm3-provider/src/lib.rs
@@ -44,7 +44,6 @@
   clippy::equatable_if_let,
   bad_style,
   clashing_extern_declarations,
-  const_err,
   dead_code,
   deprecated,
   explicit_outlives_requirements,

--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -30,16 +30,16 @@ wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.0.0" }
 log = "0.4"
-wasmtime = "4.0"
+wasmtime = "5.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.12"
 
 # feature = wasi
-wasmtime-wasi = { version = "4.0", optional = true }
-wasi-common = { version = "4.0", optional = true }
-wasi-cap-std-sync = { version = "4.0", optional = true }
+wasmtime-wasi = { version = "5.0", optional = true }
+wasi-common = { version = "5.0", optional = true }
+wasi-cap-std-sync = { version = "5.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }

--- a/crates/wasmtime-provider/src/lib.rs
+++ b/crates/wasmtime-provider/src/lib.rs
@@ -44,7 +44,6 @@
   clippy::equatable_if_let,
   bad_style,
   clashing_extern_declarations,
-  const_err,
   dead_code,
   deprecated,
   explicit_outlives_requirements,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.66.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-wasi"]
 


### PR DESCRIPTION
This time the update to latest version of wasmtime required some small changes:

- chore(deps): update rust version - wasmtime requires rust 1.66
- chore(refactor): fix clippy warnings - the update to latest version of rust raised some warnings
- chore(deps): update to latest version of wasmtime - the actual update

Once this is merged, a new version of the wasmtime provider must be tagged and released.

**Note:** I did **not** bump the version of the wasmtime-provider. I can do that if you want, it would just be a patch bump
