### PR TITLE
chore(deps): update to wasmtime 6.0

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -30,16 +30,16 @@ wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.0.0" }
 log = "0.4"
-wasmtime = "5.0"
+wasmtime = "6.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.12"
 
 # feature = wasi
-wasmtime-wasi = { version = "5.0", optional = true }
-wasi-common = { version = "5.0", optional = true }
-wasi-cap-std-sync = { version = "5.0", optional = true }
+wasmtime-wasi = { version = "6.0", optional = true }
+wasi-common = { version = "6.0", optional = true }
+wasi-cap-std-sync = { version = "6.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }

--- a/crates/wasmtime-provider/src/lib.rs
+++ b/crates/wasmtime-provider/src/lib.rs
@@ -194,19 +194,14 @@ impl WasmtimeEngineProviderPre {
 
     cfg_if::cfg_if! {
       if #[cfg(feature = "wasi")] {
-        wasmtime_wasi::add_to_linker(&mut linker, |s| &mut s.wasi_ctx).unwrap();
+        wasmtime_wasi::add_to_linker(&mut linker, |s: &mut WapcStore| &mut s.wasi_ctx).unwrap();
       }
     };
 
     // register all the waPC host functions
     callbacks::add_to_linker(&mut linker)?;
 
-    // it's fine to set the `host` to None now, because the waPC host functions
-    // are not executed yet
-    let wapc_store = WapcStore::new(&wasi_params, None)?;
-    let mut store = Store::new(&engine, wapc_store);
-
-    let instance_pre = linker.instantiate_pre(&mut store, &module)?;
+    let instance_pre = linker.instantiate_pre(&module)?;
 
     Ok(Self {
       module,
@@ -401,7 +396,7 @@ impl WebAssemblyEngineProvider for WasmtimeEngineProvider {
     );
 
     let module = Module::new(&self.engine, module)?;
-    self.instance_pre = self.linker.instantiate_pre(&mut self.store, &module)?;
+    self.instance_pre = self.linker.instantiate_pre(&module)?;
     let new_instance = self.instance_pre.instantiate(&mut self.store)?;
     *self.inner.as_ref().unwrap().instance.write() = new_instance;
 


### PR DESCRIPTION
Update to latest version of wasmtime and address the API changes.

@pkedy , @jsoverson : once merged we need to tag a new release of the wasmtime provider :pray: 