### PR TITLE
chore(deps): update wasmtime

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -30,16 +30,16 @@ wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.0.0" }
 log = "0.4"
-wasmtime = "6.0"
+wasmtime = "7.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.12"
 
 # feature = wasi
-wasmtime-wasi = { version = "6.0", optional = true }
-wasi-common = { version = "6.0", optional = true }
-wasi-cap-std-sync = { version = "6.0", optional = true }
+wasmtime-wasi = { version = "7.0", optional = true }
+wasi-common = { version = "7.0", optional = true }
+wasi-cap-std-sync = { version = "7.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }


### PR DESCRIPTION
Update to latest stable release of wasmtime

This time no API change affected us :partying_face: 
