### PR TITLE
Update wasmtime

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -30,16 +30,16 @@ wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.1.0" }
 log = "0.4"
-wasmtime = "7.0"
+wasmtime = "8.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "7.0", optional = true }
-wasi-common = { version = "7.0", optional = true }
-wasi-cap-std-sync = { version = "7.0", optional = true }
+wasmtime-wasi = { version = "8.0", optional = true }
+wasi-common = { version = "8.0", optional = true }
+wasi-cap-std-sync = { version = "8.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }

--- a/crates/wasmtime-provider/examples/wasmtime-hash-mreplace.rs
+++ b/crates/wasmtime-provider/examples/wasmtime-hash-mreplace.rs
@@ -1,4 +1,3 @@
-use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use wapc_codec::messagepack::{deserialize, serialize};
 


### PR DESCRIPTION
Update to latest stable release of wasmtime. Fix some warnings returned by clippy.

@jsoverson , @pkedy : once merged, a new version of the wasmtime provided must be tagged and released :pray: 