### PR TITLE
update wasmtime

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -30,16 +30,16 @@ wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.1.0" }
 log = "0.4"
-wasmtime = "10.0"
+wasmtime = "11.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "10.0", optional = true }
-wasi-common = { version = "10.0", optional = true }
-wasi-cap-std-sync = { version = "10.0", optional = true }
+wasmtime-wasi = { version = "11.0", optional = true }
+wasi-common = { version = "11.0", optional = true }
+wasi-cap-std-sync = { version = "11.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }


### PR DESCRIPTION
This is the usual PR that bumps the wasmtime version being consumed by the wasmtime-provider.

However, in addition to the dependency update, there's also a minor compilation fix. It turned out the wasmtime-provider didn't build when the `wasi` feature was disabled. I think this has been going on since quite some time, but we didn't notice.
Some **internal** APIs have been changed to address the compilation error. Since the changes are not done to public APIs, there's no need to tag a major release of the crate.

There's however the need to do a minor bump of the crate and to publish that to allow everybody to benefit of the new version of wasmtime.
