### PR TITLE
chore(deps): update wasmtime and rust toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ exclude = [
   "wasm/crates/wapc-guest-test",
   "wasm/crates/wapc-guest-timeout",
   "wasm/crates/wasm-calc-hash/module1",
-  "wasm/crates/wasm-calc-hash/module2"
+  "wasm/crates/wasm-calc-hash/module2",
 ]
+resolver = "2"

--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -30,16 +30,16 @@ wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.1.0" }
 log = "0.4"
-wasmtime = "11.0"
+wasmtime = "12.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "11.0", optional = true }
-wasi-common = { version = "11.0", optional = true }
-wasi-cap-std-sync = { version = "11.0", optional = true }
+wasmtime-wasi = { version = "12.0", optional = true }
+wasi-common = { version = "12.0", optional = true }
+wasi-cap-std-sync = { version = "12.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.66.0"
+channel = "1.72.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-wasi"]
 


### PR DESCRIPTION
Use latest stable release of Rust. This is required to build newer versions of wasmtime.

As a result of the update, the resolver version to be used has to be specified at the root level of the project. This is required to avoid clippy warnings.
