### PR TITLE
chore(deps): update wasmtime

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -30,16 +30,16 @@ wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.1.0" }
 log = "0.4"
-wasmtime = "12.0"
+wasmtime = "13.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "12.0", optional = true }
-wasi-common = { version = "12.0", optional = true }
-wasi-cap-std-sync = { version = "12.0", optional = true }
+wasmtime-wasi = { version = "13.0", optional = true }
+wasi-common = { version = "13.0", optional = true }
+wasi-cap-std-sync = { version = "13.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }

--- a/crates/wasmtime-provider/src/wasi.rs
+++ b/crates/wasmtime-provider/src/wasi.rs
@@ -12,10 +12,12 @@ pub(crate) fn init_ctx(
 ) -> Result<WasiCtx, Box<dyn Error + Send + Sync>> {
   let mut ctx_builder = wasi_cap_std_sync::WasiCtxBuilder::new();
 
-  ctx_builder = ctx_builder.inherit_stdio().args(argv)?.envs(env)?;
+  ctx_builder.inherit_stdio();
+  ctx_builder.args(argv)?;
+  ctx_builder.envs(env)?;
 
   for (name, file) in preopen_dirs {
-    ctx_builder = ctx_builder.preopened_dir(file.try_clone()?, name)?;
+    ctx_builder.preopened_dir(file.try_clone()?, name)?;
   }
 
   Ok(ctx_builder.build())


### PR DESCRIPTION
Update wasmtime to latest version (13.0). Fix the build issues caused by some changes to the API.
