### PR TITLE
chore(deps): update to latest stable release of wasmtime

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -30,16 +30,16 @@ wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.1.0" }
 log = "0.4"
-wasmtime = "14.0"
+wasmtime = "15.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "14.0", optional = true }
-wasi-common = { version = "14.0", optional = true }
-wasi-cap-std-sync = { version = "14.0", optional = true }
+wasmtime-wasi = { version = "15.0", optional = true }
+wasi-common = { version = "15.0", optional = true }
+wasi-cap-std-sync = { version = "15.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }


### PR DESCRIPTION
The usual update to latest version of wasmtime.

Once merged a new version of the wasmtime-provider crate should be created and released.
