### PR TITLE
chore(dependencies): update wasmtime

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -30,18 +30,18 @@ wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.1.0" }
 log = "0.4"
-wasmtime = "16.0"
+wasmtime = "17.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "16.0", optional = true }
-wasi-common = { version = "16.0", optional = true }
-wasi-cap-std-sync = { version = "16.0", optional = true }
+wasmtime-wasi = { version = "17.0", optional = true }
+wasi-common = { version = "17.0", optional = true }
+wasi-cap-std-sync = { version = "17.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }
-env_logger = "0.10"
+env_logger = "0.11"
 hex = "0.4.3"


### PR DESCRIPTION
Update wasmtime to the latest version.

Once merged, the wasmtime-provider crate should be bumped and a new relase should be made
