### PR TITLE
chore(deps): update to latest version of wasmtime

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -25,21 +25,20 @@ status = "actively-developed"
 [features]
 default = ["wasi"]
 cache = ["wasmtime/cache"]
-wasi = ["wasi-common", "wasi-cap-std-sync", "wasmtime-wasi"]
+wasi = ["wasi-common", "wasmtime-wasi"]
 
 [dependencies]
 wapc = { path = "../wapc", version = "1.1.0" }
 log = "0.4"
-wasmtime = "17.0"
+wasmtime = "18.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "17.0", optional = true }
-wasi-common = { version = "17.0", optional = true }
-wasi-cap-std-sync = { version = "17.0", optional = true }
+wasmtime-wasi = { version = "18.0", optional = true }
+wasi-common = { version = "18.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }

--- a/crates/wasmtime-provider/src/lib.rs
+++ b/crates/wasmtime-provider/src/lib.rs
@@ -99,7 +99,7 @@ use wasmtime::{AsContextMut, Engine, Instance, InstancePre, Linker, Module, Stor
 cfg_if::cfg_if! {
     if #[cfg(feature = "wasi")] {
         pub use wasmtime_wasi;
-        use wasmtime_wasi::WasiCtx;
+        use wasi_common::WasiCtx;
     }
 }
 

--- a/crates/wasmtime-provider/src/wasi.rs
+++ b/crates/wasmtime-provider/src/wasi.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::ffi::OsStr;
 use std::path::{Component, Path};
 
-use wasi_cap_std_sync::{ambient_authority, Dir};
+use wasi_common::sync::{ambient_authority, Dir, WasiCtxBuilder};
 use wasi_common::WasiCtx;
 
 pub(crate) fn init_ctx(
@@ -10,7 +10,7 @@ pub(crate) fn init_ctx(
   argv: &[String],
   env: &[(String, String)],
 ) -> Result<WasiCtx, Box<dyn Error + Send + Sync>> {
-  let mut ctx_builder = wasi_cap_std_sync::WasiCtxBuilder::new();
+  let mut ctx_builder = WasiCtxBuilder::new();
 
   ctx_builder.inherit_stdio();
   ctx_builder.args(argv)?;


### PR DESCRIPTION
Upgrade to wasmtime 18.0. Starting from this release, the `wasi-cap-std-sync` has been moved into the `wasi-common` crate.

The code has been adapted to reflect this change.
