### PR TITLE
update wasmtime

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -30,15 +30,15 @@ wasi = ["wasi-common", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.1.0" }
 log = "0.4"
-wasmtime = "18.0"
+wasmtime = "19.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "18.0", optional = true }
-wasi-common = { version = "18.0", optional = true }
+wasmtime-wasi = { version = "19.0", optional = true }
+wasi-common = { version = "19.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }

--- a/crates/wasmtime-provider/src/lib.rs
+++ b/crates/wasmtime-provider/src/lib.rs
@@ -175,7 +175,7 @@ impl WasmtimeEngineProviderPre {
 
     cfg_if::cfg_if! {
       if #[cfg(feature = "wasi")] {
-        wasmtime_wasi::add_to_linker(&mut linker, |s: &mut WapcStore| &mut s.wasi_ctx).unwrap();
+        wasi_common::sync::add_to_linker(&mut linker, |s: &mut WapcStore| &mut s.wasi_ctx).unwrap();
       }
     };
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.75"
+channel = "1.77"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-wasi"]
 


### PR DESCRIPTION
The usual update of wasmtime, plus the fixes required to make the code build.

I've also taken the opportunity to bump the Rust version used by the project.

As usual, once the PR is merged, the wasmtime-provider crate version should be bumped and released.
