### PR TITLE
update wasmtime

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,4 @@
+[advisories]
+ignore = [
+  "RUSTSEC-2024-0006", # shlex is a transitive dependency of wasm3. Unfortunately wasm3 is no longer maintained
+]

--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -30,15 +30,15 @@ wasi = ["wasi-common", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.1.0" }
 log = "0.4"
-wasmtime = "20.0"
+wasmtime = "21.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "20.0", optional = true }
-wasi-common = { version = "20.0", optional = true }
+wasmtime-wasi = { version = "21.0", optional = true }
+wasi-common = { version = "21.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }


### PR DESCRIPTION
The usual bump of the wasmtime crate. Once merged a new version of the wasmtime-provider crate has to be published.

Note: I've also add a cargo-audit configuration file to ignore a security complain produced by one the wasm3 transitive dependencies. wasm3 is unforntunately unmaintained because its author is dealing with war in his country :(
