### PR TITLE
chore(deps): update wasmtime dependency

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -30,15 +30,15 @@ wasi = ["wasi-common", "wasmtime-wasi"]
 [dependencies]
 wapc = { path = "../wapc", version = "1.1.0" }
 log = "0.4"
-wasmtime = "21.0"
+wasmtime = "22.0"
 anyhow = "1.0"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "21.0", optional = true }
-wasi-common = { version = "21.0", optional = true }
+wasmtime-wasi = { version = "22.0", optional = true }
+wasi-common = { version = "22.0", optional = true }
 
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }


### PR DESCRIPTION
wasmtime-provider: update to latest stable release of wasmtime

Once merged, the version of the crate should be bumped and a new tag should be created
