### PR TITLE
automation: automatic updates or Rust version

### DIFF
--- a/.github/workflows/update-rust-toolchain.yaml
+++ b/.github/workflows/update-rust-toolchain.yaml
@@ -1,0 +1,26 @@
+name: Update rust-toolchain
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 3 * * 1" # 3:30 on Monday
+
+jobs:
+  update-rust-toolchain:
+    name: Update Rust toolchain
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@fa41baa922561b436c449de1a0bd1f5bd768248c # v2.58.0
+
+      - name: Update rust version inside of rust-toolchain file
+        id: update_rust_toolchain
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+        run: |-
+          updatecli apply --config ./updatecli/updatecli.d/update-rust-toolchain.yaml \
+                    --values updatecli/values.yaml

--- a/updatecli/DEVELOP.md
+++ b/updatecli/DEVELOP.md
@@ -1,0 +1,6 @@
+To test the updatecli manifests locally:
+
+```console
+export UPDATECLI_GITHUB_TOKEN=<your token>
+UPDATECLI_GITHUB_OWNER=<your user> updatecli diff --config updatecli/updatecli.d/update-rust-toolchain.yaml --values updatecli/values.yaml
+```

--- a/updatecli/updatecli.d/update-rust-toolchain.yaml
+++ b/updatecli/updatecli.d/update-rust-toolchain.yaml
@@ -1,0 +1,47 @@
+title: Update Rust version inside of rust-toolchain file
+
+scms:
+  github:
+    kind: github
+    spec:
+      user: "{{ .github.author }}"
+      email: "{{ .github.email }}"
+      directory: "/tmp/wapc-rs"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "wapc-rs"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ requiredEnv .github.user }}"
+      branch: "{{ .github.branch }}"
+      commitmessage:
+        type: "fix"
+        title: "Update Rust version"
+        hidecredit: true
+
+sources:
+  rust-lang:
+    name: Get the latest release of Rust from rust-lang
+    kind: githubrelease
+    spec:
+      owner: rust-lang
+      repository: rust
+      token: "{{ requiredEnv .github.token }}"
+    transformers:
+      - find: '(\d+\.\d+\.\d+)'
+
+targets:
+  dataFile:
+    name: Bump Rust release
+    kind: toml
+    scmid: github
+    spec:
+      file: "rust-toolchain.toml"
+      key: toolchain.channel
+
+pullrequests:
+  default:
+    title: '[updatecli] Update Rust version to {{ source "rust-lang" }}'
+    kind: github
+    scmid: github
+    spec:
+      labels:
+        - chore

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,7 @@
+github:
+  owner: "UPDATECLI_GITHUB_OWNER"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "master"
+  author: "updatecli bot"
+  email: "updatecli@wapc.io"
+  user: "UPDATECLI_GITHUB_OWNER"


### PR DESCRIPTION
Use updatecli to automatically detect updates of Rust to be done inside of `rust-toolchain.toml`.

Neither dependabot nor renovatebot can handle that.
