### PR TITLE
update wasmtime

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-provider"
-version = "2.0.0"
+version = "2.1.0"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",

--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -40,7 +40,7 @@ async = [
 [dependencies]
 wapc = { path = "../wapc", version = "2.0.0" }
 log = "0.4"
-wasmtime = { version = "25.0", default-features = false, features = [
+wasmtime = { version = "26.0", default-features = false, features = [
   'cache',
   'gc',
   'wat',
@@ -63,8 +63,8 @@ cfg-if = "1.0.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "25.0", optional = true }
-wasi-common = { version = "25.0", optional = true }
+wasmtime-wasi = { version = "26.0", optional = true }
+wasi-common = { version = "26.0", optional = true }
 cap-std = { version = "3.2", optional = true }
 async-trait = { version = "0.1.81", optional = true }
 tokio = { version = "1", optional = true, default-features = false, features = [


### PR DESCRIPTION
This the usual bump of the wasmtime dependency for wasmtime-provider.

Once merged I'll tag wasmtime-provider `v2.1.0`
