### PR TITLE
update deps

### DIFF
--- a/crates/wapc-guest/Cargo.toml
+++ b/crates/wapc-guest/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "wapc-guest"
-version = "1.1.0"
+version = "1.2.0"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",
   "Phil Kedy <phil.kedy@gmail.com>",
+  "Flavio Castelli <flavio@castelli.me>",
 ]
 edition = "2021"
 description = "Guest SDK for building waPC-compliant WebAssembly Modules"
@@ -26,6 +27,6 @@ default = []
 codec = ["wapc-codec"]
 
 [dependencies]
-once_cell = "1.9"
+once_cell = "1.20"
 wapc-codec = { path = "../wapc-codec", optional = true, version = "1.1.0" }
 parking_lot = "0.12"

--- a/crates/wapc/Cargo.toml
+++ b/crates/wapc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wapc"
-version = "2.0.0"
+version = "2.1.0"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",
@@ -30,7 +30,7 @@ independent = true
 [dependencies]
 log = "0.4"
 parking_lot = "0.12"
-thiserror = "1.0"
+thiserror = "2.0"
 async-trait = { version = "0.1", optional = true }
 tokio = { version = "1", optional = true, default-features = false, features = [
   "sync",

--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-provider"
-version = "2.1.0"
+version = "2.2.0"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",
@@ -38,11 +38,13 @@ async = [
 ]
 
 [dependencies]
-wapc = { path = "../wapc", version = "2.0.0" }
+wapc = { path = "../wapc", version = "2.1.0" }
 log = "0.4"
-wasmtime = { version = "26.0", default-features = false, features = [
+wasmtime = { version = "27.0", default-features = false, features = [
   'cache',
   'gc',
+  'gc-drc',
+  'gc-null',
   'wat',
   'profiling',
   'parallel-compilation',
@@ -58,15 +60,15 @@ wasmtime = { version = "26.0", default-features = false, features = [
   'std',
 ] }
 anyhow = "1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 cfg-if = "1.0.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "26.0", optional = true }
-wasi-common = { version = "26.0", optional = true }
-cap-std = { version = "3.2", optional = true }
-async-trait = { version = "0.1.81", optional = true }
+wasmtime-wasi = { version = "27.0", optional = true }
+wasi-common = { version = "27.0", optional = true }
+cap-std = { version = "3.4", optional = true }
+async-trait = { version = "0.1", optional = true }
 tokio = { version = "1", optional = true, default-features = false, features = [
   "rt",
 ] }
@@ -74,7 +76,7 @@ tokio = { version = "1", optional = true, default-features = false, features = [
 [dev-dependencies]
 wapc-codec = { path = "../wapc-codec" }
 env_logger = "0.11"
-hex = "0.4.3"
+hex = "0.4"
 tokio = { version = "1", features = ["full"] }
 
 [[example]]


### PR DESCRIPTION
Aside from the usual wasmtime monthly update, this release includes a few minor updates to the `wapc` and `wapc-guest` dependencies. This happens because some minor dependencies have been updated also inside of these projects.

Changes:

- chore(deps): wapc-guest update deps
- chore(deps): wapc update deps
- chore(deps): bump wasmtime and other minor deps

Once merged, I'll tag care of tagging the releases.
