### PR TITLE
fix: temporarily drop wasm3 support

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,2 @@
 [advisories]
-ignore = [
-  "RUSTSEC-2024-0006", # shlex is a transitive dependency of wasm3. Unfortunately wasm3 is no longer maintained
-]
+ignore = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["crates/*"]
 exclude = [
+  "crates/wasm3-provider",              # this is temporarily disabled since the crate is no longer maintained. We hope a new maintainer will step up.
   "wasm/crates/wasm-basic",
   "wasm/crates/wasi-basic",
   "wasm/crates/wapc-guest-test",

--- a/crates/wasm3-provider/README.md
+++ b/crates/wasm3-provider/README.md
@@ -1,3 +1,11 @@
+> **WARNING:** this crate is temporarily disabled.
+> 
+> Unfortunately the `wasm3` crate is no longer maintained. It's no longer building
+> and it's also bringing vulnerable dependencies into our tree.
+>
+> We will be happy to enable this crate again once the `wasm3` finds a new maintainer
+> and the vulnerabilities are fixed.
+
 # Wasm3 Engine Provider
 
 ![crates.io](https://img.shields.io/crates/v/wasm3-provider.svg)


### PR DESCRIPTION
Disable the wasm3-provider support until the upstream project gets a new maintainer.

The `wasm3` crate is no longer maintained, it's no longer building and it's also bringing vulnerable dependencies into our tree.

We will be happy to enable the `wasm3-provider` once this situation is addressed.
