### PR TITLE
chore(deps): update wasmtime

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-provider"
-version = "2.3.1"
+version = "2.4.0"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",
@@ -40,7 +40,7 @@ async = [
 [dependencies]
 wapc = { path = "../wapc", version = "2.1.0" }
 log = "0.4"
-wasmtime = { version = "28.0", default-features = false, features = [
+wasmtime = { version = "29.0", default-features = false, features = [
   'cache',
   'gc',
   'gc-drc',
@@ -65,8 +65,8 @@ cfg-if = "1.0.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "28.0", optional = true }
-wasi-common = { version = "28.0", optional = true }
+wasmtime-wasi = { version = "29.0", optional = true }
+wasi-common = { version = "29.0", optional = true }
 cap-std = { version = "3.4", optional = true }
 async-trait = { version = "0.1", optional = true }
 tokio = { version = "1", optional = true, default-features = false, features = [


### PR DESCRIPTION
Update to latest stable release of wasmtime.

I'll tag a new release of the wasmtime-provider once this is merged.

