### PR TITLE
chore(deps): update to latest version of wasmtime

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-provider"
-version = "2.5.0"
+version = "2.6.0"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",
@@ -40,7 +40,7 @@ async = [
 [dependencies]
 wapc = { path = "../wapc", version = "2.1.0" }
 log = "0.4"
-wasmtime = { version = "30.0", default-features = false, features = [
+wasmtime = { version = "31.0", default-features = false, features = [
   'cache',
   'gc',
   'gc-drc',
@@ -65,8 +65,8 @@ cfg-if = "1.0.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "30.0", optional = true }
-wasi-common = { version = "30.0", optional = true }
+wasmtime-wasi = { version = "31.0", optional = true }
+wasi-common = { version = "31.0", optional = true }
 cap-std = { version = "3.4", optional = true }
 async-trait = { version = "0.1", optional = true }
 tokio = { version = "1", optional = true, default-features = false, features = [


### PR DESCRIPTION
Upgrade to latest stable version of wasmtime and bump the wasmtime-provider crate version

I'll tag a new release on this PR is merged.
