### PR TITLE
chore: prepare wasmtime-provider release

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-provider"
-version = "2.6.0"
+version = "2.7.0"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",


### PR DESCRIPTION
Bump the version of wasmtime-provider to tag a new minor release. This release includes the update to latest stable release of wasmtime.

I'll take care of tagging the code once this PR gets merged.
