### PR TITLE
feat!(wasmtime-provider): do not bind epoch deadline to "pre" instances

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-provider"
-version = "2.11.0"
+version = "2.12.0"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",

--- a/crates/wasmtime-provider/src/lib.rs
+++ b/crates/wasmtime-provider/src/lib.rs
@@ -104,7 +104,6 @@ pub mod errors;
 
 mod builder;
 pub use builder::WasmtimeEngineProviderBuilder;
-
 // export wasmtime and wasmtime_wasi, so that consumers of this crate can use
 // the very same version
 pub use wasmtime;
@@ -119,11 +118,16 @@ pub use wasmtime_wasi;
 /// * waPC initialization code: this is the code defined by the module inside
 ///   of the `wapc_init` or the `_start` functions
 /// * user function: the actual waPC guest function written by an user
+///
+/// Both these limits are expressed using the number of ticks that are allowed before the
+/// WebAssembly execution is interrupted.
+/// It's up to the embedder of waPC to define how much time a single tick is granted. This could
+/// be 1 second, 10 nanoseconds, or whatever the user prefers.
 #[derive(Clone, Copy, Debug)]
-struct EpochDeadlines {
+pub struct EpochDeadlines {
   /// Deadline for waPC initialization code. Expressed in number of epoch ticks
-  wapc_init: u64,
+  pub wapc_init: u64,
 
   /// Deadline for user-defined waPC function computation. Expressed in number of epoch ticks
-  wapc_func: u64,
+  pub wapc_func: u64,
 }

--- a/crates/wasmtime-provider/src/provider.rs
+++ b/crates/wasmtime-provider/src/provider.rs
@@ -32,17 +32,11 @@ pub struct WasmtimeEngineProviderPre {
   engine: Engine,
   linker: Linker<WapcStore>,
   instance_pre: InstancePre<WapcStore>,
-  epoch_deadlines: Option<EpochDeadlines>,
 }
 
 impl WasmtimeEngineProviderPre {
   #[cfg(feature = "wasi")]
-  pub(crate) fn new(
-    engine: Engine,
-    module: Module,
-    wasi: Option<WasiParams>,
-    epoch_deadlines: Option<EpochDeadlines>,
-  ) -> Result<Self> {
+  pub(crate) fn new(engine: Engine, module: Module, wasi: Option<WasiParams>) -> Result<Self> {
     let mut linker: Linker<WapcStore> = Linker::new(&engine);
 
     let wasi_params = wasi.unwrap_or_default();
@@ -59,12 +53,11 @@ impl WasmtimeEngineProviderPre {
       engine,
       linker,
       instance_pre,
-      epoch_deadlines,
     })
   }
 
   #[cfg(not(feature = "wasi"))]
-  pub(crate) fn new(engine: Engine, module: Module, epoch_deadlines: Option<EpochDeadlines>) -> Result<Self> {
+  pub(crate) fn new(engine: Engine, module: Module) -> Result<Self> {
     let mut linker: Linker<WapcStore> = Linker::new(&engine);
 
     // register all the waPC host functions
@@ -77,7 +70,6 @@ impl WasmtimeEngineProviderPre {
       engine,
       linker,
       instance_pre,
-      epoch_deadlines,
     })
   }
 
@@ -85,7 +77,7 @@ impl WasmtimeEngineProviderPre {
   ///
   /// Note: from micro-benchmarking, this method is 10 microseconds faster than
   /// `WasmtimeEngineProvider::clone`.
-  pub fn rehydrate(&self) -> Result<WasmtimeEngineProvider> {
+  pub fn rehydrate(&self, epoch_deadlines: Option<EpochDeadlines>) -> Result<WasmtimeEngineProvider> {
     let engine = self.engine.clone();
 
     #[cfg(feature = "wasi")]
@@ -99,7 +91,7 @@ impl WasmtimeEngineProviderPre {
       module: self.module.clone(),
       inner: None,
       engine,
-      epoch_deadlines: self.epoch_deadlines,
+      epoch_deadlines,
       linker: self.linker.clone(),
       instance_pre: self.instance_pre.clone(),
       store,

--- a/crates/wasmtime-provider/tests/hello.rs
+++ b/crates/wasmtime-provider/tests/hello.rs
@@ -2,7 +2,6 @@ use std::fs::read;
 
 use wapc::errors::Error;
 use wapc::WapcHost;
-
 #[cfg(feature = "async")]
 use wapc::WapcHostAsync;
 
@@ -270,10 +269,15 @@ fn runs_wapc_timeout() -> Result<(), Error> {
   engine_conf.epoch_interruption(true);
   let engine = wasmtime::Engine::new(&engine_conf).expect("cannot create wasmtime engine");
 
+  let epoch_deadlines = wasmtime_provider::EpochDeadlines {
+    wapc_init: wapc_init_deadline,
+    wapc_func: wapc_func_deadline,
+  };
+
   let wapc_engine_builder = wasmtime_provider::WasmtimeEngineProviderBuilder::new()
     .module_bytes(&module_bytes)
     .engine(engine.clone())
-    .enable_epoch_interruptions(wapc_init_deadline, wapc_func_deadline);
+    .enable_epoch_interruptions(epoch_deadlines);
   let guest = create_guest_from_builder(&wapc_engine_builder)?;
 
   std::thread::spawn(move || {
@@ -311,10 +315,15 @@ async fn runs_wapc_timeout_async() -> Result<(), Error> {
   engine_conf.async_support(true);
   let engine = wasmtime::Engine::new(&engine_conf).expect("cannot create wasmtime engine");
 
+  let epoch_deadlines = wasmtime_provider::EpochDeadlines {
+    wapc_init: wapc_init_deadline,
+    wapc_func: wapc_func_deadline,
+  };
+
   let wapc_engine_builder = wasmtime_provider::WasmtimeEngineProviderBuilder::new()
     .module_bytes(&module_bytes)
     .engine(engine.clone())
-    .enable_epoch_interruptions(wapc_init_deadline, wapc_func_deadline);
+    .enable_epoch_interruptions(epoch_deadlines);
   let guest = create_guest_async_from_builder(&wapc_engine_builder, host_callback_basic_async).await?;
 
   tokio::spawn(async move {


### PR DESCRIPTION
Do not associate the epoch deadline value to the WasmtimeEngineProviderPre.

This value can be provided at rehydration time to allow better reuse of the pre instances.

The use case is: allow the same instance of wapc module to be instantiated with different epoch deadlines, starting from the same "pre" object.

Once merged, a new minor release of the wasmtime-provider crate should be tagged. Note: I've already bumped the version.
