### PR TITLE
chore(deps): update to latest version or wasmtime

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -40,7 +40,7 @@ async = [
 [dependencies]
 wapc = { path = "../wapc", version = "2.1.0" }
 log = "0.4"
-wasmtime = { version = "36.0", default-features = false, features = [
+wasmtime = { version = "37.0", default-features = false, features = [
   'cache',
   'gc',
   'gc-drc',
@@ -65,8 +65,8 @@ cfg-if = "1.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 # feature = wasi
-wasmtime-wasi = { version = "36.0", optional = true }
-wasi-common = { version = "36.0", optional = true }
+wasmtime-wasi = { version = "37.0", optional = true }
+wasi-common = { version = "37.0", optional = true }
 cap-std = { version = "3.4", optional = true }
 async-trait = { version = "0.1", optional = true }
 tokio = { version = "1", optional = true, default-features = false, features = [


### PR DESCRIPTION
Update to latest release of wasmtime

I'll make sure this gets merged before tagging next minor release of the wasmtime-provider (see https://github.com/wapc/wapc-rs/pull/168)
