### PR TITLE
update wasmtime

### DIFF
--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-provider"
-version = "2.18.0"
+version = "2.18.1"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",

--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -40,7 +40,7 @@ async = [
 [dependencies]
 wapc = { path = "../wapc", version = "2.1.0" }
 log = "0.4"
-wasmtime = { version = "43.0", default-features = false, features = [
+wasmtime = { version = ">=43.0.1, <43.1.0", default-features = false, features = [
   'cache',
   'gc',
   'gc-drc',

--- a/crates/wasmtime-provider/src/provider.rs
+++ b/crates/wasmtime-provider/src/provider.rs
@@ -30,19 +30,7 @@ pub struct WasmtimeEngineProviderPre {
   #[cfg(feature = "wasi")]
   wasi_params: WasiParams,
   engine: Engine,
-  // NOTE: The `Linker` is wrapped in `Arc` to work around a bug in wasmtime 43
-  // where `StringPool::try_clone()` produces a clone whose internal `map` still
-  // holds `&'static str` pointers into the *original* pool's `strings` storage.
-  // Once the original `WasmtimeEngineProviderPre` is dropped (at the end of
-  // `build()`), those pointers dangle and any subsequent linker lookup (e.g.
-  // inside `replace()`) triggers undefined behaviour that surfaces as
-  // "unknown import: `wapc::__host_call` has not been defined".
-  //
-  // By sharing the linker via `Arc` instead of cloning it, we guarantee that the
-  // `StringPool::strings` backing the pool's map is kept alive as long as any
-  // `WasmtimeEngineProvider` (or `WasmtimeEngineProviderPre`) that was derived
-  // from it still exists.
-  linker: Arc<Linker<WapcStore>>,
+  linker: Linker<WapcStore>,
   instance_pre: InstancePre<WapcStore>,
 }
 
@@ -63,7 +51,7 @@ impl WasmtimeEngineProviderPre {
       module,
       wasi_params,
       engine,
-      linker: Arc::new(linker),
+      linker,
       instance_pre,
     })
   }
@@ -80,7 +68,7 @@ impl WasmtimeEngineProviderPre {
     Ok(Self {
       module,
       engine,
-      linker: Arc::new(linker),
+      linker,
       instance_pre,
     })
   }
@@ -104,7 +92,7 @@ impl WasmtimeEngineProviderPre {
       inner: None,
       engine,
       epoch_deadlines,
-      linker: Arc::clone(&self.linker),
+      linker: self.linker.clone(),
       instance_pre: self.instance_pre.clone(),
       store,
       #[cfg(feature = "wasi")]
@@ -121,7 +109,7 @@ pub struct WasmtimeEngineProvider {
   wasi_params: WasiParams,
   inner: Option<EngineInner>,
   engine: Engine,
-  linker: Arc<Linker<WapcStore>>,
+  linker: Linker<WapcStore>,
   store: Store<WapcStore>,
   instance_pre: InstancePre<WapcStore>,
   epoch_deadlines: Option<EpochDeadlines>,
@@ -145,7 +133,7 @@ impl Clone for WasmtimeEngineProvider {
           inner: None,
           engine,
           epoch_deadlines: self.epoch_deadlines,
-          linker: Arc::clone(&self.linker),
+          linker: self.linker.clone(),
           instance_pre: self.instance_pre.clone(),
           store,
           #[cfg(feature = "wasi")]
@@ -159,7 +147,7 @@ impl Clone for WasmtimeEngineProvider {
         inner: None,
         engine,
         epoch_deadlines: self.epoch_deadlines,
-        linker: Arc::clone(&self.linker),
+        linker: self.linker.clone(),
         instance_pre: self.instance_pre.clone(),
         store,
         #[cfg(feature = "wasi")]

--- a/crates/wasmtime-provider/src/provider_async.rs
+++ b/crates/wasmtime-provider/src/provider_async.rs
@@ -31,7 +31,7 @@ pub struct WasmtimeEngineProviderAsyncPre {
   #[cfg(feature = "wasi")]
   wasi_params: WasiParams,
   engine: Engine,
-  linker: Arc<Linker<WapcStoreAsync>>,
+  linker: Linker<WapcStoreAsync>,
   instance_pre: InstancePre<WapcStoreAsync>,
   epoch_deadlines: Option<EpochDeadlines>,
 }
@@ -58,7 +58,7 @@ impl WasmtimeEngineProviderAsyncPre {
       module,
       wasi_params,
       engine,
-      linker: Arc::new(linker),
+      linker,
       instance_pre,
       epoch_deadlines,
     })
@@ -76,7 +76,7 @@ impl WasmtimeEngineProviderAsyncPre {
     Ok(Self {
       module,
       engine,
-      linker: Arc::new(linker),
+      linker,
       instance_pre,
       epoch_deadlines,
     })
@@ -101,7 +101,7 @@ impl WasmtimeEngineProviderAsyncPre {
       inner: None,
       engine,
       epoch_deadlines: self.epoch_deadlines,
-      linker: Arc::clone(&self.linker),
+      linker: self.linker.clone(),
       instance_pre: self.instance_pre.clone(),
       store,
       #[cfg(feature = "wasi")]
@@ -170,7 +170,7 @@ pub struct WasmtimeEngineProviderAsync {
   wasi_params: WasiParams,
   inner: Option<EngineInner>,
   engine: Engine,
-  linker: Arc<Linker<WapcStoreAsync>>,
+  linker: Linker<WapcStoreAsync>,
   store: Store<WapcStoreAsync>,
   instance_pre: InstancePre<WapcStoreAsync>,
   epoch_deadlines: Option<EpochDeadlines>,
@@ -194,7 +194,7 @@ impl Clone for WasmtimeEngineProviderAsync {
           inner: None,
           engine,
           epoch_deadlines: self.epoch_deadlines,
-          linker: Arc::clone(&self.linker),
+          linker: self.linker.clone(),
           instance_pre: self.instance_pre.clone(),
           store,
           #[cfg(feature = "wasi")]
@@ -212,7 +212,7 @@ impl Clone for WasmtimeEngineProviderAsync {
         inner: None,
         engine,
         epoch_deadlines: self.epoch_deadlines,
-        linker: Arc::clone(&self.linker),
+        linker: self.linker.clone(),
         instance_pre: self.instance_pre.clone(),
         store,
         #[cfg(feature = "wasi")]


### PR DESCRIPTION
wasmtime 43.0.1 has been release, it includes the fix I submitted for the `Linker` issue I reported (see https://github.com/bytecodealliance/wasmtime/issues/12905).

This PR reverts the workaround I introduced while waiting for the fix to be merged upstream.
