### PR TITLE
prepare release of wasmtime provider

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,5 @@
 [advisories]
 ignore = [
   "RUSTSEC-2024-0436", # transitive dependency `paste` is no longer maintained. We have to wait for https://github.com/3Hren/msgpack-rust/issues/365 to be resolved
+  "RUSTSEC-2026-0173", # transitive dependency `proc-macro-error2` is no longer maintained. We have to wait for wasmtime to get rid of it
 ]

--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-provider"
-version = "2.20.0"
+version = "2.21.0"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",


### PR DESCRIPTION
- **ci: configure cardo audit to ignore unmaintained proc-macro-error2**
- **chore: prepare release of wasmtime-provider**
