### PR TITLE
fix/host response double clone

### DIFF
--- a/crates/wapc/Cargo.toml
+++ b/crates/wapc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wapc"
-version = "2.1.0"
+version = "2.2.0"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",

--- a/crates/wapc/Cargo.toml
+++ b/crates/wapc/Cargo.toml
@@ -38,3 +38,5 @@ tokio = { version = "1", optional = true, default-features = false, features = [
 
 [dev-dependencies]
 wasmtime-provider = { path = "../wasmtime-provider" }
+tokio = { version = "1", features = ["macros", "rt"] }
+rstest = "0.26"

--- a/crates/wapc/src/wapchost.rs
+++ b/crates/wapc/src/wapchost.rs
@@ -17,6 +17,5 @@ pub(crate) static GLOBAL_MODULE_COUNT: AtomicU64 = AtomicU64::new(1);
 pub(crate) type Result<T> = std::result::Result<T, errors::Error>;
 
 pub use host::WapcHost;
-
 #[cfg(feature = "async")]
 pub use host_async::WapcHostAsync;

--- a/crates/wapc/src/wapchost/host.rs
+++ b/crates/wapc/src/wapchost/host.rs
@@ -1,12 +1,10 @@
-use std::{
-  cell::RefCell,
-  sync::{atomic::Ordering, Arc},
-};
+use std::cell::RefCell;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
-use crate::wapchost::{
-  errors, modulestate::ModuleState, traits::WebAssemblyEngineProvider, HostCallback, Invocation, Result,
-  GLOBAL_MODULE_COUNT,
-};
+use crate::wapchost::modulestate::ModuleState;
+use crate::wapchost::traits::WebAssemblyEngineProvider;
+use crate::wapchost::{errors, HostCallback, Invocation, Result, GLOBAL_MODULE_COUNT};
 
 /// A WebAssembly host runtime for waPC-compliant modules
 ///

--- a/crates/wapc/src/wapchost/host_async.rs
+++ b/crates/wapc/src/wapchost/host_async.rs
@@ -1,14 +1,12 @@
-use std::sync::{atomic::Ordering, Arc};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-use crate::{
-  wapchost::{
-    errors, modulestate_async::ModuleStateAsync, traits::WebAssemblyEngineProviderAsync, Invocation, Result,
-    GLOBAL_MODULE_COUNT,
-  },
-  HostCallbackAsync,
-};
+use crate::wapchost::modulestate_async::ModuleStateAsync;
+use crate::wapchost::traits::WebAssemblyEngineProviderAsync;
+use crate::wapchost::{errors, Invocation, Result, GLOBAL_MODULE_COUNT};
+use crate::HostCallbackAsync;
 
 /// A WebAssembly host runtime for waPC-compliant modules that can be used in async contexts
 ///

--- a/crates/wapc/src/wapchost/modulestate.rs
+++ b/crates/wapc/src/wapchost/modulestate.rs
@@ -38,8 +38,29 @@ impl ModuleState {
   }
 
   /// Retrieves the value of the current host response
+  #[deprecated(
+    note = "This clones the whole host response buffer. Prefer `host_response_len()` and/or \
+            `with_host_response()`, which avoid the clone."
+  )]
   pub fn get_host_response(&self) -> Option<Vec<u8>> {
     self.host_response.read().clone()
+  }
+
+  /// Returns the length of the current host response, without cloning it.
+  ///
+  /// This exists to avoid the double-clone previously incurred by calling
+  /// `get_host_response()`.
+  pub fn host_response_len(&self) -> usize {
+    self.host_response.read().as_ref().map_or(0, |v| v.len())
+  }
+
+  /// Runs `f` with a borrowed view of the current host response, without
+  /// cloning it. Returns `None` if there is no host response set.
+  ///
+  /// This exists to avoid the double-clone previously incurred by calling
+  /// `get_host_response()`.
+  pub fn with_host_response<R>(&self, f: impl FnOnce(&[u8]) -> R) -> Option<R> {
+    self.host_response.read().as_ref().map(|v| f(v.as_slice()))
   }
 
   /// Sets a value indicating that an error occurred inside the execution of a guest call
@@ -108,5 +129,61 @@ impl std::fmt::Debug for ModuleState {
       .field("host_callback", &self.host_callback.as_ref().map(|_| Some("Some(Fn)")))
       .field("id", &self.id)
       .finish()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use rstest::rstest;
+
+  use super::*;
+
+  fn state_with_callback(response: Vec<u8>) -> ModuleState {
+    let callback: Box<HostCallback> =
+      Box::new(move |_id, _binding, _namespace, _operation, _payload| Ok(response.clone()));
+    ModuleState::new(Some(callback), 0)
+  }
+
+  #[rstest]
+  #[case::no_host_call_made(None, false, None, None)]
+  #[case::successful_host_call(Some(vec![1, 2, 3, 4, 5]), true, Some(1), Some(vec![1, 2, 3, 4, 5]))]
+  #[case::failed_host_call_missing_callback(None, true, Some(0), None)]
+  fn host_response_accessors(
+    #[case] callback_response: Option<Vec<u8>>,
+    #[case] invoke_call: bool,
+    #[case] expected_return_code: Option<i32>,
+    #[case] expected_response: Option<Vec<u8>>,
+  ) {
+    let state = callback_response.map_or_else(|| ModuleState::new(None, 0), state_with_callback);
+
+    if invoke_call {
+      let result = state.do_host_call("binding", "namespace", "operation", b"payload");
+      assert_eq!(Some(result.unwrap()), expected_return_code);
+    }
+
+    match expected_response {
+      Some(bytes) => {
+        assert_eq!(state.host_response_len(), bytes.len());
+        assert_eq!(state.with_host_response(|b| b.to_vec()), Some(bytes));
+      }
+      None => {
+        assert_eq!(state.host_response_len(), 0);
+        assert_eq!(state.with_host_response(|b| b.to_vec()), None);
+      }
+    }
+  }
+
+  #[test]
+  #[allow(deprecated)]
+  fn get_host_response_still_works_for_backward_compatibility() {
+    let expected = vec![1, 2, 3, 4, 5];
+    let state = state_with_callback(expected.clone());
+
+    assert_eq!(state.get_host_response(), None);
+
+    let result = state.do_host_call("binding", "namespace", "operation", b"payload");
+    assert_eq!(result.unwrap(), 1);
+
+    assert_eq!(state.get_host_response(), Some(expected));
   }
 }

--- a/crates/wapc/src/wapchost/modulestate_async.rs
+++ b/crates/wapc/src/wapchost/modulestate_async.rs
@@ -40,8 +40,32 @@ impl ModuleStateAsync {
   }
 
   /// Retrieves the value of the current host response
+  #[deprecated(
+    note = "This clones the whole host response buffer. Prefer `host_response_len()` and/or \
+            `with_host_response()`, which avoid the clone."
+  )]
   pub async fn get_host_response(&self) -> Option<Vec<u8>> {
     self.host_response.read().await.clone()
+  }
+
+  /// Returns the length of the current host response, without cloning it.
+  ///
+  /// This exists to avoid the double-clone previously incurred by calling
+  /// `get_host_response()`.
+  pub async fn host_response_len(&self) -> usize {
+    self.host_response.read().await.as_ref().map_or(0, |v| v.len())
+  }
+
+  /// Runs `f` with a borrowed view of the current host response, without
+  /// cloning it. Returns `None` if there is no host response set.
+  ///
+  /// Note: `f` must be a plain (non-async) closure since it's called
+  /// synchronously while holding the read guard.
+  ///
+  /// This exists to avoid the double-clone previously incurred by calling
+  /// `get_host_response()`.
+  pub async fn with_host_response<R>(&self, f: impl FnOnce(&[u8]) -> R) -> Option<R> {
+    self.host_response.read().await.as_ref().map(|v| f(v.as_slice()))
   }
 
   /// Sets a value indicating that an error occurred inside the execution of a guest call
@@ -110,5 +134,78 @@ impl std::fmt::Debug for ModuleStateAsync {
       .field("host_callback", &self.host_callback.as_ref().map(|_| Some("Some(Fn)")))
       .field("id", &self.id)
       .finish()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use rstest::rstest;
+
+  use super::*;
+
+  fn state_with_callback(response: Vec<u8>) -> ModuleStateAsync {
+    let callback: Box<HostCallbackAsync> = Box::new(move |_id, _binding, _namespace, _operation, _payload| {
+      let response = response.clone();
+      Box::pin(async move { Ok(response) })
+    });
+    ModuleStateAsync::new(Some(callback), 0)
+  }
+
+  #[rstest]
+  #[case::no_host_call_made(None, false, None, None)]
+  #[case::successful_host_call(Some(vec![1, 2, 3, 4, 5]), true, Some(1), Some(vec![1, 2, 3, 4, 5]))]
+  #[case::failed_host_call_missing_callback(None, true, Some(0), None)]
+  #[tokio::test]
+  async fn host_response_accessors(
+    #[case] callback_response: Option<Vec<u8>>,
+    #[case] invoke_call: bool,
+    #[case] expected_return_code: Option<i32>,
+    #[case] expected_response: Option<Vec<u8>>,
+  ) {
+    let state = callback_response.map_or_else(|| ModuleStateAsync::new(None, 0), state_with_callback);
+
+    if invoke_call {
+      let result = state
+        .do_host_call(
+          "binding".into(),
+          "namespace".into(),
+          "operation".into(),
+          b"payload".to_vec(),
+        )
+        .await;
+      assert_eq!(Some(result.unwrap()), expected_return_code);
+    }
+
+    match expected_response {
+      Some(bytes) => {
+        assert_eq!(state.host_response_len().await, bytes.len());
+        assert_eq!(state.with_host_response(|b| b.to_vec()).await, Some(bytes));
+      }
+      None => {
+        assert_eq!(state.host_response_len().await, 0);
+        assert_eq!(state.with_host_response(|b| b.to_vec()).await, None);
+      }
+    }
+  }
+
+  #[tokio::test]
+  #[allow(deprecated)]
+  async fn get_host_response_still_works_for_backward_compatibility() {
+    let expected = vec![1, 2, 3, 4, 5];
+    let state = state_with_callback(expected.clone());
+
+    assert_eq!(state.get_host_response().await, None);
+
+    let result = state
+      .do_host_call(
+        "binding".into(),
+        "namespace".into(),
+        "operation".into(),
+        b"payload".to_vec(),
+      )
+      .await;
+    assert_eq!(result.unwrap(), 1);
+
+    assert_eq!(state.get_host_response().await, Some(expected));
   }
 }

--- a/crates/wapc/src/wapchost/traits.rs
+++ b/crates/wapc/src/wapchost/traits.rs
@@ -1,12 +1,13 @@
-use std::{error::Error, sync::Arc};
+use std::error::Error;
+use std::sync::Arc;
 
 #[cfg(feature = "async")]
 use async_trait::async_trait;
 
+use crate::wapchost::modulestate::ModuleState;
 #[cfg(feature = "async")]
 use crate::wapchost::modulestate_async::ModuleStateAsync;
-
-use crate::{wapchost::modulestate::ModuleState, Invocation};
+use crate::Invocation;
 
 /// The module host (waPC) must provide an implementation of this trait to the engine provider
 /// to enable waPC function calls.

--- a/crates/wasm3-provider/src/callbacks.rs
+++ b/crates/wasm3-provider/src/callbacks.rs
@@ -36,13 +36,13 @@ pub(crate) fn guest_request(ctx: &CallContext, op_ptr: i32, ptr: i32, host: &Arc
 }
 
 pub(crate) fn host_response(ctx: &CallContext, ptr: i32, host: &Arc<ModuleState>) {
-  if let Some(ref r) = host.get_host_response() {
-    write_bytes_to_memory(ctx, ptr, r);
-  }
+  host.with_host_response(|bytes| {
+    write_bytes_to_memory(ctx, ptr, bytes);
+  });
 }
 
 pub(crate) fn host_response_length(_ctx: &CallContext, host: &Arc<ModuleState>) -> i32 {
-  host.get_host_response().unwrap_or_default().len() as i32
+  host.host_response_len() as i32
 }
 
 pub(crate) fn console_log(ctx: &CallContext, ptr: i32, len: i32, host: &Arc<ModuleState>) {

--- a/crates/wasmtime-provider/Cargo.toml
+++ b/crates/wasmtime-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-provider"
-version = "2.21.0"
+version = "2.22.0"
 authors = [
   "Kevin Hoffman <alothien@gmail.com>",
   "Jarrod Overson <jsoverson@gmail.com>",
@@ -38,7 +38,7 @@ async = [
 ]
 
 [dependencies]
-wapc = { path = "../wapc", version = "2.1.0" }
+wapc = { path = "../wapc", version = "2.2.0" }
 log = "0.4"
 wasmtime = { version = "46.0", default-features = false, features = [
   'cache',

--- a/crates/wasmtime-provider/src/callbacks.rs
+++ b/crates/wasmtime-provider/src/callbacks.rs
@@ -128,11 +128,13 @@ fn register_host_response_func(linker: &mut Linker<WapcStore>) -> Result<()> {
         let host = caller
           .data()
           .host
-          .as_ref()
+          .clone()
           .ok_or_else(|| format_err!("host should have been set during the init"))?;
 
-        if let Some(ref e) = host.get_host_response() {
-          write_bytes_to_memory(caller.as_context_mut(), memory, ptr, e)?;
+        let write_result =
+          host.with_host_response(|bytes| write_bytes_to_memory(caller.as_context_mut(), memory, ptr, bytes));
+        if let Some(result) = write_result {
+          result?;
         }
         Ok(())
       },
@@ -156,7 +158,7 @@ fn register_host_response_len_func(linker: &mut Linker<WapcStore>) -> Result<()>
           .as_ref()
           .ok_or_else(|| format_err!("host should have been set during the init"))?;
 
-        let len = host.get_host_response().map_or_else(|| 0, |r| r.len()) as i32;
+        let len = host.host_response_len() as i32;
         Ok(len)
       },
     )

--- a/crates/wasmtime-provider/src/callbacks_async.rs
+++ b/crates/wasmtime-provider/src/callbacks_async.rs
@@ -131,11 +131,14 @@ fn register_host_response_func(linker: &mut Linker<WapcStoreAsync>) -> Result<()
           let host = caller
             .data()
             .host
-            .as_ref()
+            .clone()
             .ok_or_else(|| format_err!("host should have been set during the init"))?;
 
-          if let Some(ref e) = host.get_host_response().await {
-            write_bytes_to_memory(caller.as_context_mut(), memory, ptr, e)?;
+          let write_result = host
+            .with_host_response(|bytes| write_bytes_to_memory(caller.as_context_mut(), memory, ptr, bytes))
+            .await;
+          if let Some(result) = write_result {
+            result?;
           }
           Ok(())
         })
@@ -161,7 +164,7 @@ fn register_host_response_len_func(linker: &mut Linker<WapcStoreAsync>) -> Resul
             .as_ref()
             .ok_or_else(|| format_err!("host should have been set during the init"))?;
 
-          let len = host.get_host_response().await.map_or_else(|| 0, |r| r.len()) as i32;
+          let len = host.host_response_len().await as i32;
           Ok(len)
         })
       },

--- a/crates/wasmtime-provider/src/wasi.rs
+++ b/crates/wasmtime-provider/src/wasi.rs
@@ -2,7 +2,8 @@ use std::error::Error;
 use std::ffi::OsStr;
 use std::path::{Component, Path};
 
-use cap_std::{ambient_authority, fs::Dir};
+use cap_std::ambient_authority;
+use cap_std::fs::Dir;
 use wasi_common::WasiCtx;
 
 pub(crate) fn init_ctx(

--- a/crates/wasmtime-provider/tests/calc_hash.rs
+++ b/crates/wasmtime-provider/tests/calc_hash.rs
@@ -1,10 +1,9 @@
 use std::fs::read;
 
-use wapc::{errors, WapcHost};
-use wapc_codec::messagepack::{deserialize, serialize};
-
 #[cfg(feature = "async")]
 use wapc::WapcHostAsync;
+use wapc::{errors, WapcHost};
+use wapc_codec::messagepack::{deserialize, serialize};
 
 #[test]
 fn runs_wapc_guest() -> Result<(), errors::Error> {

--- a/crates/wasmtime-provider/tests/wapc_guest.rs
+++ b/crates/wasmtime-provider/tests/wapc_guest.rs
@@ -1,10 +1,8 @@
 use serde::{Deserialize, Serialize};
-
-use wapc::{errors, WapcHost};
-use wapc_codec::messagepack::{deserialize, serialize};
-
 #[cfg(feature = "async")]
 use wapc::WapcHostAsync;
+use wapc::{errors, WapcHost};
+use wapc_codec::messagepack::{deserialize, serialize};
 
 const WAPC_FUNCTION_NAME: &str = "serdes_example";
 


### PR DESCRIPTION
While assessing a review comment on a project making use of waPC, I realised we could do a minor optimization when dealing with the host response.

The `get_host_response()` cloned the response Vec once for `__host_response_len` and again for `__host_response`, on every host callback.

This PR adds `host_response_len()` and `with_host_response()` methods to `ModuleState`/`ModuleStateAsync` (inside of `wapc` crate) for clone-free access.
The it uses them in `wasmtime-provider` and `wasm3-provider` (which I know, is currently disabled but it was a cheap edit) callbacks, cutting copies per callback from 3 to 1. This can be significant when the host response is a big.

This PR deprecates `get_host_response()` in favor of the new accessors, keeping it for backward compatibility. We can remove this legacy API in a future major release of the `wapc` create.

This PR also does a minor bump of the `wapc` and `wasmtime-provider` crates. I'll take care of that once this gets merged.
